### PR TITLE
Chore: library bump

### DIFF
--- a/app/repositories/SessionRepository.scala
+++ b/app/repositories/SessionRepository.scala
@@ -20,12 +20,11 @@ import config.FrontendAppConfig
 import models.UserAnswers
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.*
-import org.mongodb.scala.SingleObservableFuture
 import play.api.libs.json.Format
+import uk.gov.hmrc.mdc.Mdc
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
-import uk.gov.hmrc.play.http.logging.Mdc
 
 import java.time.{Clock, Instant}
 import java.util.concurrent.TimeUnit

--- a/it/test/routes/AuthActionISpec.scala
+++ b/it/test/routes/AuthActionISpec.scala
@@ -17,9 +17,8 @@
 package routes
 
 import config.FrontendAppConfig
-import support.MockAuthHelper.authSession
-import org.jsoup.Jsoup
 import play.api.http.{HeaderNames, Status}
+import support.MockAuthHelper.authSession
 import support.{ISpecBase, MockAuthHelper, SessionCookieBaker}
 
 class AuthActionISpec extends ISpecBase {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.7.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.8.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % hmrcMongoVersion
   )


### PR DESCRIPTION
* bumped play-frontend-hmrc-play-30 to 12.8.0
* replaced the deprecated uk.gov.hmrc.play.http.logging.Mdc
* removed unused import in it/test/routes/AuthActionISpec.scala