### PR TITLE
SAOD-614 - MA - Refactors ContactEmailSummary to set data-test-id locators correctly

### DIFF
--- a/app/viewmodels/checkAnswers/ContactEmailSummary.scala
+++ b/app/viewmodels/checkAnswers/ContactEmailSummary.scala
@@ -30,6 +30,6 @@ object ContactEmailSummary {
       value = email,
       changeUrl = routes.ContactEmailController.onPageLoad(contactType, CheckMode).url,
       hiddenTextMessageKey = s"contactEmail.change.${contactType.messageKey}.hidden",
-      testIdPrefix = "first-contact-email"
+      testIdPrefix = s"${contactType.messageKey}-contact-email"
     )
 }


### PR DESCRIPTION
testIdPrefix was hard coded to "first-contact ..." and so the test locators set are incorrect for a second contact. This change fixes the email locators.