### PR TITLE
add sign up endpoint

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -74,6 +74,12 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, val configuration: Co
   def stubGrs: Boolean              = isEnabled(StubGrs)
   def grsAllowsRelativeUrl: Boolean = isEnabled(GrsAllowRelativeUrl)
 
+  val etmpSubscriptionUrl: String =
+    s"${servicesConfig.baseUrl("etmp-subscription-api")}${configuration.get[String]("microservice.services.etmp-subscription-api.path")}"
+
+  val etmpSubscriptionAuthorizationToken: String =
+    configuration.get[String]("microservice.services.etmp-subscription-api.authorization-token")
+
 }
 
 object AppConfig {

--- a/app/connectors/EtmpSubscriptionConnector.scala
+++ b/app/connectors/EtmpSubscriptionConnector.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import connectors.EtmpSubscriptionConnector.given
+import models.signup.{EtmpSubscriptionRequest, EtmpSubscriptionResponse}
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import play.api.libs.ws.writeableOf_JsValue
+import play.api.mvc.RequestHeader
+import uk.gov.hmrc.http.*
+import uk.gov.hmrc.http.client.HttpClientV2
+import utils.FrontendHeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+import java.net.URI
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant}
+import java.util.UUID
+import javax.inject.Inject
+
+class EtmpSubscriptionConnector @Inject() (
+    appConfig: AppConfig,
+    http: HttpClientV2,
+    clock: Clock
+)(using
+    ExecutionContext
+) {
+
+  def subscribe(
+      request: EtmpSubscriptionRequest
+  )(using requestHeader: RequestHeader): Future[Either[Exception, EtmpSubscriptionResponse]] = {
+    given HeaderCarrier = FrontendHeaderCarrier(requestHeader)
+
+    http
+      .post(URI(appConfig.etmpSubscriptionUrl).toURL)
+      .setHeader(headers*)
+      .withBody(Json.toJson(request))
+      .execute[Either[Exception, EtmpSubscriptionResponse]]
+      .recover { case exception: Exception =>
+        Left(exception)
+      }
+  }
+
+  private def headers: Seq[(String, String)] =
+    Seq(
+      "Content-Type"          -> "application/json",
+      "Authorization"         -> s"Basic ${appConfig.etmpSubscriptionAuthorizationToken}",
+      "X-Transmitting-System" -> "HIP",
+      "X-Originating-System"  -> "MDTP",
+      "correlationid"         -> UUID.randomUUID().toString,
+      "X-Receipt-Date"        -> Instant.now(clock).truncatedTo(ChronoUnit.SECONDS).toString
+    )
+}
+
+object EtmpSubscriptionConnector {
+
+  given HttpReads[Either[Exception, EtmpSubscriptionResponse]] =
+    (method: String, url: String, response: HttpResponse) =>
+      response.status match {
+        case CREATED =>
+          (for {
+            json      <- Try(response.json).toEither
+            validated <- json.validate[EtmpSubscriptionResponse].asEither
+          } yield validated).left
+            .map(_ => new InternalServerException("ETMP subscription returned invalid body"))
+        case status =>
+          Left(new InternalServerException(s"ETMP subscription failed with status: $status"))
+      }
+}

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions.ApiAuthenticatedIdentifierAction
+import models.signup.SignUpRequest
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.SignUpService
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
+
+class SignUpController @Inject() (
+    val controllerComponents: MessagesControllerComponents,
+    identify: ApiAuthenticatedIdentifierAction,
+    signUpService: SignUpService
+)(using
+    ExecutionContext
+) extends FrontendBaseController {
+
+  def signUp: Action[AnyContent] = identify.async { implicit request =>
+    request.body.asJson.fold(Future.successful(BadRequest)) { json =>
+      json
+        .validate[SignUpRequest]
+        .fold(
+          _ => Future.successful(BadRequest),
+          signUpRequest =>
+            signUpService.signUp(signUpRequest).map {
+              case Right(response) => Created(Json.toJson(response))
+              case Left(_)         => BadGateway
+            }
+        )
+    }
+  }
+}

--- a/app/models/signup/SignUpModels.scala
+++ b/app/models/signup/SignUpModels.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.signup
+
+import play.api.libs.functional.syntax.*
+import play.api.libs.json.{Json, JsonValidationError, OFormat, OWrites, Reads, __}
+
+final case class SignUpRequest(idType: String, idNumber: String)
+
+object SignUpRequest {
+
+  private val utrRegex = "^[0-9]{10}$".r
+
+  given Reads[SignUpRequest] = (
+    (__ \ "idType").read[String].filter(JsonValidationError("error.expected.utr"))(_ == "UTR") and
+      (__ \ "idNumber").read[String].filter(JsonValidationError("error.expected.10.digits"))(utrRegex.matches)
+  )(SignUpRequest.apply)
+
+  given OWrites[SignUpRequest] = Json.writes[SignUpRequest]
+}
+
+final case class EtmpSubscriptionRequest(idType: String, idNumber: String)
+
+object EtmpSubscriptionRequest {
+  given OWrites[EtmpSubscriptionRequest] = Json.writes[EtmpSubscriptionRequest]
+
+  def fromSignUpRequest(request: SignUpRequest): EtmpSubscriptionRequest =
+    EtmpSubscriptionRequest(request.idType, request.idNumber)
+}
+
+final case class EtmpSubscriptionResponse(saoSubscriptionId: String)
+
+object EtmpSubscriptionResponse {
+  given OFormat[EtmpSubscriptionResponse] = Json.format[EtmpSubscriptionResponse]
+}
+
+final case class SignUpResponse(saoSubscriptionId: String)
+
+object SignUpResponse {
+  given OWrites[SignUpResponse] = Json.writes[SignUpResponse]
+}

--- a/app/services/SignUpService.scala
+++ b/app/services/SignUpService.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.EtmpSubscriptionConnector
+import models.signup.{EtmpSubscriptionRequest, SignUpRequest, SignUpResponse}
+import play.api.mvc.RequestHeader
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import javax.inject.Inject
+
+class SignUpService @Inject() (etmpSubscriptionConnector: EtmpSubscriptionConnector)(using ExecutionContext) {
+
+  def signUp(request: SignUpRequest)(using RequestHeader): Future[Either[Exception, SignUpResponse]] =
+    etmpSubscriptionConnector
+      .subscribe(EtmpSubscriptionRequest.fromSignUpRequest(request))
+      .map(_.map(response => SignUpResponse(response.saoSubscriptionId)))
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -24,6 +24,8 @@ GET         /registration-complete                             controllers.Regis
 GET         /business-match                                    controllers.GrsController.start()
 GET         /business-match/result                             controllers.GrsController.callBack(journeyId: String)
 
+POST        /sign-up                                           controllers.SignUpController.signUp()
+
 GET         /contact-details                                   controllers.ContactDetailsGuidanceController.onPageLoad()
 POST        /contact-details                                   controllers.ContactDetailsGuidanceController.continue()
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,14 @@ microservice {
       host     = localhost
       port     = 10057
     }
+
+    etmp-subscription-api {
+      protocol = http
+      host     = localhost
+      port     = 10060
+      path = "/etmp/subscriptions"
+      authorization-token = "local-token"
+    }
   }
 }
 

--- a/it/test/connectors/EtmpSubscriptionConnectorISpec.scala
+++ b/it/test/connectors/EtmpSubscriptionConnectorISpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import connectors.EtmpSubscriptionConnectorISpec.*
+import models.signup.{EtmpSubscriptionRequest, EtmpSubscriptionResponse}
+import org.scalatest.EitherValues
+import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.mvc.Request
+import play.api.test.FakeRequest
+import support.ISpecBase
+
+class EtmpSubscriptionConnectorISpec extends ISpecBase with EitherValues {
+
+  override def additionalConfigs: Map[String, Any] = Map(
+    "microservice.services.etmp-subscription-api.port"                -> wireMockPort,
+    "microservice.services.etmp-subscription-api.path"                -> "/etmp/subscriptions",
+    "microservice.services.etmp-subscription-api.authorization-token" -> "test-token"
+  )
+
+  val SUT          = app.injector.instanceOf[EtmpSubscriptionConnector]
+  given Request[?] = FakeRequest()
+
+  "EtmpSubscriptionConnector.subscribe" - {
+    "must post the expected request to ETMP and return the subscription ID" in {
+      mockEtmpSubscription()
+
+      val result = SUT.subscribe(EtmpSubscriptionRequest("UTR", testUtr)).futureValue
+
+      result.value mustBe EtmpSubscriptionResponse(testSubscriptionId)
+
+      verify(
+        postRequestedFor(urlEqualTo("/etmp/subscriptions"))
+          .withHeader("Authorization", equalTo("Basic test-token"))
+          .withHeader("X-Transmitting-System", equalTo("HIP"))
+          .withHeader("X-Originating-System", equalTo("MDTP"))
+          .withHeader("correlationid", matching("[0-9a-fA-F-]{36}"))
+          .withHeader("X-Receipt-Date", matching("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"))
+          .withRequestBody(equalTo(Json.obj("idType" -> "UTR", "idNumber" -> testUtr).toString))
+      )
+    }
+
+    "must return Left when ETMP returns a non-201 response" in {
+      mockEtmpSubscription(status = Status.INTERNAL_SERVER_ERROR)
+
+      SUT.subscribe(EtmpSubscriptionRequest("UTR", testUtr)).futureValue mustBe a[Left[?, ?]]
+    }
+
+    "must return Left when ETMP returns a 201 response with an invalid body" in {
+      mockEtmpSubscription(body = Json.obj("unexpected" -> "value").toString)
+
+      SUT.subscribe(EtmpSubscriptionRequest("UTR", testUtr)).futureValue mustBe a[Left[?, ?]]
+    }
+  }
+}
+
+object EtmpSubscriptionConnectorISpec {
+  val testSubscriptionId = "XE0001234567890"
+  val testUtr            = "1234567890"
+
+  def mockEtmpSubscription(
+      status: Int = Status.CREATED,
+      body: String = Json.obj("saoSubscriptionId" -> testSubscriptionId).toString
+  ) =
+    stubFor(
+      post(urlEqualTo("/etmp/subscriptions"))
+        .willReturn(
+          aResponse()
+            .withHeader("content-type", "application/json")
+            .withBody(body)
+            .withStatus(status)
+        )
+    )
+}

--- a/it/test/routes/SignUpISpec.scala
+++ b/it/test/routes/SignUpISpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routes
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import routes.SignUpISpec.*
+import play.api.http.HeaderNames
+import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.libs.ws.writeableOf_JsValue
+import support.{ISpecBase, MockAuthHelper}
+
+class SignUpISpec extends ISpecBase {
+
+  override def additionalConfigs: Map[String, Any] = Map(
+    "microservice.services.etmp-subscription-api.port"                -> wireMockPort,
+    "microservice.services.etmp-subscription-api.path"                -> "/etmp/subscriptions",
+    "microservice.services.etmp-subscription-api.authorization-token" -> "test-token"
+  )
+
+  private val targetUrl = s"$baseUrl/senior-accounting-officer/registration/sign-up"
+
+  "POST /sign-up" - {
+    "must call ETMP and return the subscription ID" in {
+      MockAuthHelper.mockAuthOk()
+      mockEtmpSubscription()
+
+      val response =
+        wsClient
+          .url(targetUrl)
+          .withHttpHeaders(
+            HeaderNames.AUTHORIZATION -> "Bearer mock-bearer-token",
+            "Csrf-Token"       -> "nocheck"
+          )
+          .post(validSignUpRequestJson)
+          .futureValue
+
+      response.status mustBe Status.CREATED
+      response.json mustBe Json.obj("saoSubscriptionId" -> testSubscriptionId)
+      verify(postRequestedFor(urlEqualTo("/etmp/subscriptions")))
+    }
+  }
+}
+
+object SignUpISpec {
+  private val testSubscriptionId = "XE0001234567890"
+  private val testUtr            = "1234567890"
+
+  private val validSignUpRequestJson = Json.obj(
+    "idType"   -> "UTR",
+    "idNumber" -> testUtr
+  )
+
+  private def mockEtmpSubscription() =
+    stubFor(
+      post(urlEqualTo("/etmp/subscriptions"))
+        .willReturn(
+          aResponse()
+            .withHeader("content-type", "application/json")
+            .withBody(Json.obj("saoSubscriptionId" -> testSubscriptionId).toString)
+            .withStatus(Status.CREATED)
+        )
+    )
+}

--- a/test/controllers/SignUpControllerSpec.scala
+++ b/test/controllers/SignUpControllerSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import controllers.SignUpControllerSpec.*
+import models.signup.{SignUpRequest, SignUpResponse}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.http.HeaderNames.CONTENT_TYPE
+import play.api.http.MimeTypes.JSON
+import play.api.inject
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import services.SignUpService
+import uk.gov.hmrc.http.InternalServerException
+
+import scala.concurrent.Future
+
+class SignUpControllerSpec extends SpecBase with MockitoSugar {
+
+  override def applicationBuilder(userAnswers: Option[models.UserAnswers] = None) =
+    super
+      .applicationBuilder(userAnswers)
+      .overrides(
+        inject.bind[SignUpService].toInstance(mock[SignUpService])
+      )
+
+  "SignUpController.signUp" - {
+    "must return 201 with the subscription ID" in {
+      val application = applicationBuilder().build()
+
+      running(application) {
+        val service = application.injector.instanceOf[SignUpService]
+
+        when(service.signUp(any[SignUpRequest])(using any())).thenReturn(
+          Future.successful(Right(SignUpResponse(testSubscriptionId)))
+        )
+
+        val result = route(application, jsonRequest(validSignUpRequestJson)).value
+
+        status(result) mustBe CREATED
+        contentAsJson(result) mustBe Json.obj("saoSubscriptionId" -> testSubscriptionId)
+      }
+    }
+
+    "must return 400 for an invalid request body" in {
+      val application = applicationBuilder().build()
+
+      running(application) {
+        val result = route(application, jsonRequest(Json.obj("idType" -> "UTR", "idNumber" -> "12345"))).value
+
+        status(result) mustBe BAD_REQUEST
+      }
+    }
+
+    "must return 502 when ETMP subscription fails" in {
+      val application = applicationBuilder().build()
+
+      running(application) {
+        val service = application.injector.instanceOf[SignUpService]
+
+        when(service.signUp(any[SignUpRequest])(using any())).thenReturn(
+          Future.successful(Left(new InternalServerException("ETMP failed")))
+        )
+
+        val result = route(application, jsonRequest(validSignUpRequestJson)).value
+
+        status(result) mustBe BAD_GATEWAY
+      }
+    }
+  }
+
+  private def jsonRequest(body: play.api.libs.json.JsObject) =
+    FakeRequest(POST, routes.SignUpController.signUp().url)
+      .withHeaders(CONTENT_TYPE -> JSON)
+      .withJsonBody(body)
+}
+
+object SignUpControllerSpec {
+  private val testSubscriptionId     = "XE0001234567890"
+  private val testUtr                = "1234567890"
+  private val validSignUpRequestJson = Json.obj(
+    "idType"   -> "UTR",
+    "idNumber" -> testUtr
+  )
+}

--- a/test/models/signup/SignUpRequestSpec.scala
+++ b/test/models/signup/SignUpRequestSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.signup
+
+import base.SpecBase
+import models.signup.SignUpRequestSpec.*
+import play.api.libs.json.Json
+
+class SignUpRequestSpec extends SpecBase {
+
+  "SignUpRequest" - {
+    "must read a valid UTR request" in {
+      validSignUpRequestJson.validate[SignUpRequest].asOpt mustBe Some(
+        SignUpRequest("UTR", testUtr)
+      )
+    }
+
+    "must reject an idType that is not UTR" in {
+      Json.obj("idType" -> "NINO", "idNumber" -> testUtr).validate[SignUpRequest].isError mustBe true
+    }
+
+    "must reject an idNumber that is not 10 digits" in {
+      Json.obj("idType" -> "UTR", "idNumber" -> "12345").validate[SignUpRequest].isError mustBe true
+      Json.obj("idType" -> "UTR", "idNumber" -> "123456789A").validate[SignUpRequest].isError mustBe true
+    }
+  }
+}
+
+object SignUpRequestSpec {
+  private val testUtr                = "1234567890"
+  private val validSignUpRequestJson = Json.obj(
+    "idType"   -> "UTR",
+    "idNumber" -> testUtr
+  )
+}

--- a/test/services/SignUpServiceSpec.scala
+++ b/test/services/SignUpServiceSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import connectors.EtmpSubscriptionConnector
+import models.signup.{EtmpSubscriptionResponse, SignUpRequest, SignUpResponse}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.Request
+import play.api.test.FakeRequest
+import uk.gov.hmrc.http.InternalServerException
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import SignUpServiceSpec.*
+
+class SignUpServiceSpec extends SpecBase with MockitoSugar {
+
+  given Request[?] = FakeRequest()
+
+  "SignUpService.signUp" - {
+    "must return the subscription ID from ETMP" in {
+      val connector = mock[EtmpSubscriptionConnector]
+      val service   = SignUpService(connector)
+
+      when(connector.subscribe(any())(using any())).thenReturn(
+        Future.successful(Right(EtmpSubscriptionResponse(testSubscriptionId)))
+      )
+
+      service.signUp(SignUpRequest("UTR", testUtr)).futureValue mustBe Right(
+        SignUpResponse(testSubscriptionId)
+      )
+
+      verify(connector).subscribe(any())(using any())
+    }
+
+    "must return the ETMP error when subscription fails" in {
+      val connector = mock[EtmpSubscriptionConnector]
+      val service   = SignUpService(connector)
+      val error     = new InternalServerException("ETMP failed")
+
+      when(connector.subscribe(any())(using any())).thenReturn(Future.successful(Left(error)))
+
+      service.signUp(SignUpRequest("UTR", testUtr)).futureValue mustBe Left(error)
+    }
+  }
+}
+
+object SignUpServiceSpec {
+  val testSubscriptionId = "XE0001234567890"
+  val testUtr            = "1234567890"
+}


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Creating a new POST /sign-up endpoint on the registration protected microservice that:
* Calls the ETMP API (via stub in local/lower environments).
* Returns the subscription ID from the ETMP 201 response.

## Jira ticket(s):
* SAOD-864

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [X] Is the branch up to date with main?
* [X] Have you added tests for any changed functionality?
* [X] Have you run the unit test?
* [X] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [X] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
