### PR TITLE
SAOD-900 & SAOD-1107 align email validation with email service, + bug fix to name property test

### DIFF
--- a/app/forms/ContactEmailFormProvider.scala
+++ b/app/forms/ContactEmailFormProvider.scala
@@ -16,14 +16,13 @@
 
 package forms
 
+import forms.ContactEmailFormProvider.emailRegex
 import forms.mappings.Mappings
 import play.api.data.Form
 
 import javax.inject.Inject
 
 class ContactEmailFormProvider @Inject() extends Mappings {
-
-  val emailRegex = """^.+[@].+[.].+$"""
 
   def apply(): Form[String] =
     Form(
@@ -32,4 +31,9 @@ class ContactEmailFormProvider @Inject() extends Mappings {
         .verifying(regexp(emailRegex, "contactEmail.error.format"))
     )
 
+}
+
+object ContactEmailFormProvider {
+  // to align with email service https://github.com/hmrc/email/blob/main/app/uk/gov/hmrc/email/emailaddress/EmailAddress.scala#L28C1-L36C6
+  val emailRegex = """^([a-zA-Z0-9.!#$%&’'*+/=?^_`{|}~-]+)@([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)$"""
 }

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -87,7 +87,7 @@ trait Generators extends ModelGenerators {
   def stringsWithMaxLength(maxLength: Int): Gen[String] =
     for {
       length <- choose(1, maxLength)
-      chars  <- listOfN(length, arbitrary[Char])
+      chars  <- listOfN(length, arbitrary[Char].filterNot(Set[Char]('<', '>', '&').contains))
     } yield chars.mkString
 
   def invalidStringsForNameFieldWithMaxLength(maxLength: Int): Gen[String] =
@@ -163,8 +163,8 @@ trait Generators extends ModelGenerators {
   def genInvalidEmailAddresses: Gen[String] = {
     Gen.oneOf(
       Gen.const("notAnEmail"),
-      Gen.const("missing@domain"),
       Gen.const("@noDomain.com"),
+      Gen.const("end@withdot."),
       Gen.const("missingAtSign.com")
     )
   }

--- a/test/forms/ContactEmailFormProviderSpec.scala
+++ b/test/forms/ContactEmailFormProviderSpec.scala
@@ -26,7 +26,7 @@ class ContactEmailFormProviderSpec extends StringFieldBehaviours {
   val formatKey   = "contactEmail.error.format"
   val maxLength   = 50
 
-  val emailRegex = """^.+[@].+[.].+$"""
+  val emailRegex = """^([a-zA-Z0-9.!#$%&’'*+/=?^_`{|}~-]+)@([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)$"""
 
   val form = new ContactEmailFormProvider()()
 


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* align email regex validation to the same as the HMRC's email service
* fixed a sporadic name validation bug
> - must bind valid data *** FAILED ***
[info]   TestFailedException was thrown during property evaluation.
[info]     Message: List(FormError("value", List("contactName.error.invalidChars"), ArraySeq())) was not empty
[info]     Location: (FieldBehaviours.scala:34)
[info]     Occurred when passed generated values (
[info]       validDataItem = "萉㯦ꏄ΃Ὗ㵬⡓頄溶>뼢ಈꮴ봝邦ꘓجṓൂ㉻蚗"
[info]     )
[info]   Init Seed: -81772358384644498

## Jira ticket(s):
* [SAOD-900](https://jira.tools.tax.service.gov.uk/browse/SAOD-900)
* [SAOD-1107](https://jira.tools.tax.service.gov.uk/browse/SAOD-1107)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [x] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
